### PR TITLE
fix: app name display in task manager, windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epherome-beta",
-  "version": "1.0.0-2",
+  "version": "1.0.0-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "epherome-beta",
-      "version": "1.0.0-2",
+      "version": "1.0.0-4",
       "dependencies": {
         "@tauri-apps/api": "^1.5.3",
         "nanoid": "^5.0.5",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "epherome-beta"
 version = "0.0.0"
-description = "A Tauri App"
+description = "Epherome"
 authors = ["you"]
 license = ""
 repository = ""


### PR DESCRIPTION
Before making the modification, Windows task manager would display the `Epherome` as `A Tauri App`, and this error has been fixed according to the recommendations of the official community.